### PR TITLE
chore: align staged publish workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: npm
@@ -54,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -93,10 +93,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: npm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,21 +16,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: '26.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
-          always-auth: true
 
       - name: Install dependencies
         run: npm ci
 
-      # - name: Run all checks and build
-      #   run: npm run all
+      - name: Run all checks and build
+        run: npm run all
 
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
@@ -47,12 +46,12 @@ jobs:
             echo "is_prerelease=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish to npm
-        run: npm publish --provenance --access public --tag ${{ steps.release-info.outputs.npm_tag }}
+      - name: Stage publish to npm
+        run: npm stage publish --provenance --access public --tag ${{ steps.release-info.outputs.npm_tag }}
 
       - name: Create GitHub Release
-        if: steps.release-info.outputs.is_prerelease == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
-          prerelease: ${{ steps.release-info.outputs.is_prerelease == 'true' }}
+          prerelease: true
+          make_latest: false


### PR DESCRIPTION
Align release workflow with the ctrf-js staged publish template and normalize actions/checkout and actions/setup-node to @v6 in main workflow where present.